### PR TITLE
为邮箱链接增加 `mailto:`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ robots:
     crawl: index,follow
 
 # website address when deployed, also given as canonical link
-url: https://tsjensen.github.io/fuse-core/
+url: https://das-may.github.io/
 
 # The 'baseurl' is prepended to all website-internal links.
 # 'baseurl' will often be '', but for a project page on gh-pages, it needs to be the project name.
@@ -41,10 +41,6 @@ baseurl: '/fuse-core'
 # Also, some places require you to anonymize the users' IPs, which can be enabled via 'anonymizeip' below. You normally want that.
 # https://support.google.com/analytics/answer/2763052
 #ga:
-ga:
-    account: 'UA-120960520-1'
-    cookieconsent: true
-    anonymizeip: true
 
 # Plausible.io Analytics (alternative to Google Analytics that does not need cookies -> no cookie consent required)
 # A config setting is required in plausible to enable tracking of the outbound links. Details described here:
@@ -52,7 +48,6 @@ ga:
 # Leave empty (just "plausible:" with subitems commented out) to disable.
 #plausible:
 plausible:
-    domain: 'tsjensen.github.io'
 
 
 # A picture of you, square(!), at least 180x180 pixels, more is better. Recommended file size < 100 KB.
@@ -169,7 +164,7 @@ links:
   - email:
       name: Email
       show: true
-      href: 1352341468@qq.com
+      href: mailto:1352341468@qq.com
       icon: fas fa-envelope
   - publickey:
       name: PGP Key


### PR DESCRIPTION
这样子点击链接才会跳转到邮箱，不然是无效链接。另外删除了一些不属于你的配置